### PR TITLE
RISCV: Added SerialServer and TimeServer support for hifive platform

### DIFF
--- a/components/SerialServer/include/plat/hifive/plat/serial.h
+++ b/components/SerialServer/include/plat/hifive/plat/serial.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019, Data61
+ * Copyright 2019, DornerWorks
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_DORNERWORKS_BSD)
+ */
+#pragma once
+
+#define HARDWARE_SERIAL_INTERFACES  \
+    emits Dummy dummy_source;       \
+    consumes Dummy serial_dev;
+
+#define HARDWARE_SERIAL_ATTRIBUTES
+
+#define HARDWARE_SERIAL_COMPOSITION                                                 \
+        connection seL4DTBHardware serial_conn(from dummy_source, to serial_dev);
+
+#define HARDWARE_SERIAL_CONFIG                               \
+        serial_dev.dtb = dtb({ "chosen" : "stdout-path" });  \
+        serial_dev.generate_interrupts = 1;

--- a/components/SerialServer/src/plat/hifive/plat.c
+++ b/components/SerialServer/src/plat/hifive/plat.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019, Data61
+ * Copyright 2019, DornerWorks
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_DORNERWORKS_BSD)
+ */
+
+#include <autoconf.h>
+#include <sel4/sel4.h>
+#include <camkes.h>
+#include <utils/util.h>
+#include <platsupport/irq.h>
+#include <sel4utils/sel4_zf_logif.h>
+
+#include "../../plat.h"
+#include "../../serial.h"
+
+void plat_post_init(ps_irq_ops_t *irq_ops)
+{
+    ps_irq_t irq_info = { .type = PS_INTERRUPT, .irq = { .number = DEFAULT_SERIAL_INTERRUPT }};
+    irq_id_t serial_irq_id = ps_irq_register(irq_ops, irq_info, serial_server_irq_handle, NULL);
+    ZF_LOGF_IFERR(serial_irq_id < 0, "Failed to register irq for serial");
+}

--- a/components/TimeServer/include/plat/hifive/plat/timers.h
+++ b/components/TimeServer/include/plat/hifive/plat/timers.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019, Data61
+ * Copyright 2019, DornerWorks
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_DORNERWORKS_BSD)
+ */
+#pragma once
+
+#define HARDWARE_TIMER_INTERFACES                                                   \
+    consumes Dummy pwm0_timer;                                                      \
+    consumes Dummy pwm1_timer;                                                      \
+    emits Dummy dummy_source;
+
+#define HARDWARE_TIMER_ATTRIBUTES
+
+#define HARDWARE_TIMER_COMPOSITION                                                        \
+        connection seL4DTBHardware pwm_timer_conn0(from dummy_source, to pwm0_timer);     \
+        connection seL4DTBHardware pwm_timer_conn1(from dummy_source, to pwm1_timer);
+
+#define HARDWARE_TIMER_CONFIG                                                             \
+        pwm0_timer.dtb = dtb({"path" : "/soc/pwm@10020000"});                             \
+        pwm0_timer.generate_interrupts = 1;                                               \
+        pwm1_timer.dtb = dtb({"path" : "/soc/pwm@10021000"});                             \
+        pwm1_timer.generate_interrupts = 1;
+
+#define HARDWARE_TIMER_PLAT_INTERFACES


### PR DESCRIPTION
These two patches are very close to the arm_common implementations, as they are copied from there and modified accordingly. 