### PR TITLE
TimeServer: remove include of non-existing "timers.camkes"

### DIFF
--- a/components/TimeServer/TimeServer.camkes
+++ b/components/TimeServer/TimeServer.camkes
@@ -14,7 +14,6 @@
 
 import <Timer.idl4>;
 import <PutChar.idl4>;
-import <timers.camkes>;
 
 #ifdef HARDWARE_TIMER_COMPONENT
     HARDWARE_TIMER_COMPONENT


### PR DESCRIPTION
The file `timers.camkes` does not exists anywhere, so it remains unclear why it is included here. proposal is to remove it, but we can also keep it an add a comment explaining, why we include this.