### PR TITLE
templates: add architecture parameter

### DIFF
--- a/templates/global-endpoint.template.c
+++ b/templates/global-endpoint.template.c
@@ -27,7 +27,7 @@
     /*? raise(Exception('%s.%s_global_endpoint can no longer be set to an arbirtary value: %s %s' % (instance, interface_end.interface.name, config_name, name))) ?*/
   /*- endif -*/
 
-  /*- set badge = macros.global_endpoint_badges(composition, interface_end, configuration) -*/
+  /*- set badge = macros.global_endpoint_badges(composition, interface_end, configuration, options.architecture) -*/
   /*- set stash_name = "%s_global_notification" % (name) -*/
 
   /*# Check the global stash for our endpoint #*/

--- a/templates/seL4DTBHardwareThreadless.template.c
+++ b/templates/seL4DTBHardwareThreadless.template.c
@@ -117,7 +117,7 @@
 
     /*# CAmkES has a maximum limit of 28 bits for badges, #*/
     /*# highly unlikely a device has greater than 28 #*/
-    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28) ?*/
+    /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28, options.architecture) ?*/
     /*- set badges =  macros.global_endpoint_badges(composition, me, configuration) -*/
     /*- set irq_set = pop('irq_set') -*/
     /*- set name = '%s_global_endpoint' % me.instance.name -*/


### PR DESCRIPTION
Adapt to the recent CAmkES changes, the architecture is passed now to parse the DTB interrupts properly.

Change are related to https://github.com/seL4/camkes-tool/pull/79


