### PR TITLE
templates: autogenerated template header

### DIFF
--- a/global-connectors.cmake
+++ b/global-connectors.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright 2018, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2021, HENSOLDT Cyber GmbH
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -10,14 +11,13 @@ CAmkESAddImportPath(interfaces plat_interfaces/${KernelPlatform})
 
 CAmkESAddTemplatesPath(templates)
 
+# Connector templates with FROM and TO only
 foreach(
     connector
     IN
     ITEMS
-    seL4RPCDataportSignal
     seL4GlobalAsynch
     seL4GlobalAsynchCallback
-    seL4Ethdriver
     seL4MessageQueue
     seL4RPCOverMultiSharedData
 )
@@ -30,6 +30,32 @@ foreach(
     )
 endforeach()
 
+# Connector templates with FROM, FROM_HEADER, TO and TO_HEADER
+foreach(
+    connector
+    IN
+    ITEMS
+    seL4RPCCallSignal
+    seL4RPCDataport
+    seL4RPCDataportSignal
+    seL4RPCNoThreads
+    seL4GPIOServer
+    seL4Ethdriver
+)
+    DeclareCAmkESConnector(
+        ${connector}
+        FROM
+        ${connector}-from.template.c
+        FROM_HEADER
+        ${connector}-from.template.h
+        TO
+        ${connector}-to.template.c
+        TO_HEADER
+        ${connector}-to.template.h
+    )
+endforeach()
+
+# Specific connector templates not fitting with the schemes above
 DeclareCAmkESConnector(
     seL4SharedDataWithCaps
     FROM
@@ -43,25 +69,7 @@ DeclareCAmkESConnector(
     FROM
     seL4RPCCallSignal-from.template.c
     FROM_HEADER
-    get-notification.template.h
-    TO
-    seL4RPCCallSignal-to.template.c
-)
-
-DeclareCAmkESConnector(
-    seL4SerialServer
-    FROM
-    seL4RPCDataportSignal-from.template.c
-    FROM_HEADER
-    get-notification.template.h
-    TO
-    seL4RPCDataportSignal-to.template.c
-)
-
-DeclareCAmkESConnector(
-    seL4RPCCallSignal
-    FROM
-    seL4RPCCallSignal-from.template.c
+    seL4RPCCallSignal-from.template.h
     TO
     seL4RPCCallSignal-to.template.c
     TO_HEADER
@@ -69,9 +77,21 @@ DeclareCAmkESConnector(
 )
 
 DeclareCAmkESConnector(
+    seL4SerialServer
+    FROM
+    seL4RPCDataportSignal-from.template.c
+    FROM_HEADER
+    seL4RPCDataportSignal-from.template.h
+    TO
+    seL4RPCDataportSignal-to.template.c
+)
+
+DeclareCAmkESConnector(
     seL4RPCCallSignalNoThreads
     FROM
     seL4RPCCallSignal-from.template.c
+    FROM_HEADER
+    seL4RPCCallSignal-from.template.h
     TO
     seL4RPCCallSignal-to.template.c
     TO_HEADER
@@ -83,7 +103,7 @@ DeclareCAmkESConnector(
     FROM
     seL4RPCCallSignal-from.template.c
     FROM_HEADER
-    get-notification.template.h
+    seL4RPCCallSignal-from.template.h
     TO
     seL4RPCCallSignal-to.template.c
     TO_HEADER
@@ -91,19 +111,11 @@ DeclareCAmkESConnector(
 )
 
 DeclareCAmkESConnector(
-    seL4RPCDataport
-    FROM
-    seL4RPCDataport-from.template.c
-    TO
-    seL4RPCDataport-to.template.c
-    TO_HEADER
-    seL4RPCDataport-to.template.h
-)
-
-DeclareCAmkESConnector(
     seL4RPCDataportNoThreads
     FROM
     seL4RPCDataport-from.template.c
+    FROM_HEADER
+    seL4RPCDataport-from.template.h
     TO
     seL4RPCDataport-to.template.c
     TO_HEADER
@@ -114,6 +126,8 @@ DeclareCAmkESConnector(
     seL4PicoServer
     FROM
     seL4RPCDataport-from.template.c
+    FROM_HEADER
+    seL4RPCDataport-from.template.h
     TO
     seL4RPCDataport-to.template.c
     TO_HEADER
@@ -122,16 +136,6 @@ DeclareCAmkESConnector(
 
 DeclareCAmkESConnector(
     seL4GlobalAsynchHardwareInterrupt TO seL4GlobalAsynchHardwareInterrupt.template.c
-)
-
-DeclareCAmkESConnector(
-    seL4RPCNoThreads
-    FROM
-    seL4RPCNoThreads-from.template.c
-    TO
-    seL4RPCNoThreads-to.template.c
-    TO_HEADER
-    seL4RPCNoThreads-to.template.h
 )
 
 DeclareCAmkESConnector(
@@ -152,16 +156,4 @@ DeclareCAmkESConnector(
     seL4VirtQueues-to.template.c
     FROM_HEADER
     seL4VirtQueues-from.template.h
-)
-
-DeclareCAmkESConnector(
-    seL4GPIOServer
-    FROM
-    seL4GPIOServer-from.template.c
-    TO
-    seL4GPIOServer-to.template.c
-    FROM_HEADER
-    seL4GPIOServer-from.template.h
-    TO_HEADER
-    seL4GPIOServer-to.template.h
 )

--- a/templates/rpc-signalling.template.h
+++ b/templates/rpc-signalling.template.h
@@ -1,0 +1,11 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+#include <sel4/sel4.h>
+
+/*# Declare all the function prototypes for this connector. #*/
+void /*? me.interface.name ?*/_emit(unsigned int badge);
+int /*? me.interface.name ?*/_largest_badge(void);

--- a/templates/seL4Ethdriver-from.template.h
+++ b/templates/seL4Ethdriver-from.template.h
@@ -1,0 +1,9 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+
+/*- include 'seL4RPCDataport-from.template.h' -*/
+/*- include 'get-notification.template.h' -*/

--- a/templates/seL4Ethdriver-to.template.h
+++ b/templates/seL4Ethdriver-to.template.h
@@ -1,0 +1,15 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+
+#include <sel4/sel4.h>
+
+/*- include 'seL4RPCDataport-to.template.h' -*/
+
+/*# Declare all the function prototypes for this connector. #*/
+void /*? me.interface.name ?*/_emit(unsigned int badge);
+bool /*? me.interface.name ?*/_has_mac(unsigned int badge);
+void /*? me.interface.name ?*/_get_mac(unsigned int badge, uint8_t *mac);

--- a/templates/seL4MultiSharedData-from.template.c
+++ b/templates/seL4MultiSharedData-from.template.c
@@ -37,8 +37,11 @@
 
 volatile void * /*? shmem_name ?*/ = (volatile void *) & /*? shmem_symbol ?*/;
 
-size_t /*? me.interface.name ?*/_get_size(void)
-{
+volatile void * /*? me.interface.name ?*/_get_buf(void) {
+    return /*? shmem_name ?*/;
+}
+
+size_t /*? me.interface.name ?*/_get_size(void) {
     return ROUND_UP_UNSAFE(/*? shmem_size ?*/, PAGE_SIZE_4K);
 }
 

--- a/templates/seL4MultiSharedData-from.template.c
+++ b/templates/seL4MultiSharedData-from.template.c
@@ -37,7 +37,8 @@
 
 volatile void * /*? shmem_name ?*/ = (volatile void *) & /*? shmem_symbol ?*/;
 
-size_t /*? me.interface.name ?*/_get_size(void) {
+size_t /*? me.interface.name ?*/_get_size(void)
+{
     return ROUND_UP_UNSAFE(/*? shmem_size ?*/, PAGE_SIZE_4K);
 }
 

--- a/templates/seL4MultiSharedData-from.template.h
+++ b/templates/seL4MultiSharedData-from.template.h
@@ -1,0 +1,11 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+
+#include <sel4/sel4.h>
+
+/*# Declare all the function prototypes for this connector. #*/
+size_t /*? me.interface.name ?*/_get_size(void);

--- a/templates/seL4MultiSharedData-from.template.h
+++ b/templates/seL4MultiSharedData-from.template.h
@@ -8,4 +8,5 @@
 #include <sel4/sel4.h>
 
 /*# Declare all the function prototypes for this connector. #*/
+volatile void * /*? me.interface.name ?*/_get_buf(void);
 size_t /*? me.interface.name ?*/_get_size(void);

--- a/templates/seL4MultiSharedData-to.template.h
+++ b/templates/seL4MultiSharedData-to.template.h
@@ -1,0 +1,12 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+#include <sel4/sel4.h>
+
+void * /*? me.interface.name ?*/_buf(seL4_Word client_id);
+size_t /*? me.interface.name ?*/_buf_size(seL4_Word client_id);
+unsigned int /*? me.interface.name ?*/_num_badges(void);
+seL4_Word /*? me.interface.name ?*/_enumerate_badge(unsigned int i);

--- a/templates/seL4RPCCallSignal-from.template.h
+++ b/templates/seL4RPCCallSignal-from.template.h
@@ -1,5 +1,4 @@
 /*#
- *#Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
  *#Copyright 2021, HENSOLDT Cyber GmbH
  *#
  *#SPDX-License-Identifier: BSD-2-Clause
@@ -7,7 +6,7 @@
 
 
 /*- if me.parent.type.to_threads == 0 -*/
-    /*- include 'seL4RPCNoThreads-to.template.h' -*/
+    /*- include 'seL4RPCNoThreads-from.template.h' -*/
 /*- endif -*/
 
-/*- include 'rpc-signalling.template.h' -*/
+/*- include 'get-notification.template.h' -*/

--- a/templates/seL4RPCDataport-from.template.h
+++ b/templates/seL4RPCDataport-from.template.h
@@ -1,5 +1,4 @@
 /*#
- *#Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
  *#Copyright 2021, HENSOLDT Cyber GmbH
  *#
  *#SPDX-License-Identifier: BSD-2-Clause
@@ -7,7 +6,7 @@
 
 
 /*- if me.parent.type.to_threads == 0 -*/
-    /*- include 'seL4RPCNoThreads-to.template.h' -*/
+    /*- include 'seL4RPCNoThreads-from.template.h' -*/
 /*- endif -*/
 
-/*- include 'rpc-signalling.template.h' -*/
+/*- include 'seL4MultiSharedData-from.template.h' -*/

--- a/templates/seL4RPCDataport-to.template.h
+++ b/templates/seL4RPCDataport-to.template.h
@@ -1,9 +1,13 @@
 /*#
  *#Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
+ *#Copyright 2021, HENSOLDT Cyber GmbH
  *#
  *#SPDX-License-Identifier: BSD-2-Clause
   #*/
 
+
 /*- if me.parent.type.to_threads == 0 -*/
     /*- include 'seL4RPCNoThreads-to.template.h' -*/
 /*- endif -*/
+
+/*- include 'seL4MultiSharedData-to.template.h' -*/

--- a/templates/seL4RPCDataportSignal-from.template.h
+++ b/templates/seL4RPCDataportSignal-from.template.h
@@ -1,0 +1,9 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+/*- include 'seL4RPCDataport-from.template.h' -*/
+
+/*- include 'get-notification.template.h' -*/

--- a/templates/seL4RPCDataportSignal-to.template.h
+++ b/templates/seL4RPCDataportSignal-to.template.h
@@ -1,0 +1,9 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+/*- include 'seL4RPCDataport-to.template.h' -*/
+
+/*- include 'rpc-signalling.template.h' -*/

--- a/templates/seL4RPCNoThreads-from.template.h
+++ b/templates/seL4RPCNoThreads-from.template.h
@@ -1,0 +1,8 @@
+/*#
+ *#Copyright 2021, HENSOLDT Cyber GmbH
+ *#
+ *#SPDX-License-Identifier: BSD-2-Clause
+  #*/
+
+/*# This template is intentionally empty.
+  #*/


### PR DESCRIPTION
CAmkES can generate header files for functions defined in the connector templates. For many connector types this is missing, so users need to define the prototypes of functions they want to use themselves.
This PR adds autogenerated header files for missing connector functions and slightly restructures global-connector.cmake to group connectors with complete, default definition (FROM, FROM_HEADER, TO, TO_HEADER with connector name == file name) from connectors with non-standard definitions.