### PR TITLE
templates: add missing architecture parameter

### DIFF
--- a/templates/seL4DTBHardwareThreadless.template.c
+++ b/templates/seL4DTBHardwareThreadless.template.c
@@ -118,7 +118,7 @@
     /*# CAmkES has a maximum limit of 28 bits for badges, #*/
     /*# highly unlikely a device has greater than 28 #*/
     /*? dtb_macros.parse_dtb_node_interrupts(dtb, 28, options.architecture) ?*/
-    /*- set badges =  macros.global_endpoint_badges(composition, me, configuration) -*/
+    /*- set badges =  macros.global_endpoint_badges(composition, me, configuration, options.architecture) -*/
     /*- set irq_set = pop('irq_set') -*/
     /*- set name = '%s_global_endpoint' % me.instance.name -*/
 /*- set stash_name = "%s_global_notification" % (name) -*/


### PR DESCRIPTION
This change should have been part of commit 7e476394 actually.