### PR TITLE
SerialServer: use the default value for interrupt

### DIFF
--- a/components/SerialServer/src/plat/pc99/plat.c
+++ b/components/SerialServer/src/plat/pc99/plat.c
@@ -16,7 +16,7 @@
 
 void plat_post_init(ps_irq_ops_t *irq_ops)
 {
-    ps_irq_t irq_info = { .type = PS_IOAPIC, .ioapic = { .ioapic = 0, .pin = 4, .level = 0, .polarity = 0, .vector = 4 }};
+    ps_irq_t irq_info = { .type = PS_IOAPIC, .ioapic = { .ioapic = 0, .pin = DEFAULT_SERIAL_INTERRUPT, .level = 0, .polarity = 0, .vector = DEFAULT_SERIAL_INTERRUPT }};
     irq_id_t serial_irq_id = ps_irq_register(irq_ops, irq_info, serial_server_irq_handle, NULL);
     ZF_LOGF_IFERR(serial_irq_id < 0, "Failed to register irq for serial");
 }


### PR DESCRIPTION
Since we allow users to change the config for serial ports, the
serial server component should also use the serial port that's
config by the users instead of a hardcoded one.

Signed-off-by: Jingyao Zhou <jingyao.zhou@unsw.edu.au>