### PR TITLE
templates: use options.architecture

### DIFF
--- a/templates/seL4SharedDataWithCaps.template.c
+++ b/templates/seL4SharedDataWithCaps.template.c
@@ -51,8 +51,7 @@
 /*- set shmem_symbol_size = "MAX_UNSAFE(%s, %s)" % (type_size, dataport_size) -*/
 /*? macros.shared_buffer_symbol(sym=dataport_symbol_name, shmem_size=shmem_symbol_size, page_size=page_size) ?*/
 
-/*- set arch_name = obj_space.spec.arch.capdl_name() -*/
-/*- if arch_name in ['aarch32', 'aarch64', 'arm_hyp', 'ia32', 'x86_64'] -*/
+/*- if options.architecture in ['aarch32', 'arm_hyp', 'aarch64', 'ia32', 'x86_64'] -*/
     /*- set cached_default = true -*/
 /*- else -*/
     /*- set cached_default = false -*/

--- a/templates/seL4SharedDataWithCaps.template.c
+++ b/templates/seL4SharedDataWithCaps.template.c
@@ -60,7 +60,7 @@
 /*- set cached = configuration[me.instance.name].get('%s_hardware_cached' % me.interface.name, cached_default) -*/
 
 /*- if 'paddr' in configuration[me.parent.name] and me in me.parent.to_ends -*/
-  /*- set paddr = configuration[me.parent.name].get('paddr') -*/  
+  /*- set paddr = configuration[me.parent.name].get('paddr') -*/
 /*- else -*/
   /*- set paddr = None -*/
 /*- endif -*/


### PR DESCRIPTION
Follow-up from https://github.com/seL4/global-components/pull/32#discussion_r897436147

Prefer `options.architecture` over `obj_space.spec.arch.capdl_name()`. The latter one returns `arm11` on aarch32/armv7 due to historical reasons, which is quite counter intuitive.