### PR TITLE
RPi 4 TimeServer/SerialServer fixes and updates

### DIFF
--- a/components/SerialServer/CMakeLists.txt
+++ b/components/SerialServer/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright 2018, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2022, Technology Innovation Institute
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -17,7 +18,11 @@ set(CAmkESCPP ON CACHE BOOL "" FORCE)
 # ARM platforms have similar serial configurations in their DTSes and can share
 # similar headers and code
 if(KernelArchARM)
-    set(PlatPrefix "arm_common")
+    if(KernelPlatformRpi4)
+        set(PlatPrefix "bcm2711")
+    else()
+        set(PlatPrefix "arm_common")
+    endif()
 else()
     set(PlatPrefix "${KernelPlatform}")
 endif()

--- a/components/SerialServer/SerialServer.camkes
+++ b/components/SerialServer/SerialServer.camkes
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +13,10 @@ import <Batch.idl4>;
 import <Timer.idl4>;
 import <serial.camkes>;
 import <VirtQueue/VirtQueue.camkes>;
+
+#ifdef HARDWARE_SERIAL_COMPONENT
+    HARDWARE_SERIAL_COMPONENT
+#endif
 
 component SerialServer {
     control;

--- a/components/SerialServer/include/plat/bcm2711/plat/serial.h
+++ b/components/SerialServer/include/plat/bcm2711/plat/serial.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+#define HARDWARE_SERIAL_COMPONENT                                      \
+    component GPIOHW {                                                 \
+        hardware;                                                      \
+        dataport Buf(4096) mem;                                        \
+    }
+
+#define HARDWARE_SERIAL_INTERFACES  \
+    dataport Buf(4096) gpiohw_mem;  \
+    emits Dummy dummy_source;       \
+    consumes Dummy serial_dev;
+
+#define HARDWARE_SERIAL_ATTRIBUTES
+
+#define HARDWARE_SERIAL_COMPOSITION                                                 \
+        component GPIOHW gpio_hw;                                                   \
+        connection seL4DTBHardware serial_conn(from dummy_source, to serial_dev);   \
+        connection seL4HardwareMMIO gpio_mem(from gpiohw_mem, to gpio_hw.mem);
+
+#define HARDWARE_SERIAL_CONFIG                               \
+        serial_dev.dtb = dtb({ "chosen" : "stdout-path" });  \
+        serial_dev.generate_interrupts = 1;                  \
+        gpio_hw.mem_paddr = 0xfe200000;                      \
+        gpio_hw.mem_size = 0x1000;

--- a/components/SerialServer/src/plat/bcm2711/plat.c
+++ b/components/SerialServer/src/plat/bcm2711/plat.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <autoconf.h>
+#include <sel4/sel4.h>
+#include <camkes.h>
+#include <utils/util.h>
+#include <platsupport/irq.h>
+#include <sel4utils/sel4_zf_logif.h>
+
+#include "../../plat.h"
+#include "../../serial.h"
+
+void plat_post_init(ps_irq_ops_t *irq_ops)
+{
+    ps_irq_t irq_info = { .type = PS_INTERRUPT, .irq = { .number = DEFAULT_SERIAL_INTERRUPT }};
+    irq_id_t serial_irq_id = ps_irq_register(irq_ops, irq_info, serial_server_irq_handle, NULL);
+    ZF_LOGF_IFERR(serial_irq_id < 0, "Failed to register irq for serial");
+}

--- a/components/TimeServer/include/plat/bcm2711/plat/timers.h
+++ b/components/TimeServer/include/plat/bcm2711/plat/timers.h
@@ -6,36 +6,13 @@
  */
 #pragma once
 
-#define HARDWARE_TIMER_COMPONENT                                       \
-    component HWTimer {                                                \
-        hardware;                                                      \
-        dataport Buf(4096) mem;                                        \
-        emits TimerIRQ irq;                                            \
-    }
-
-#define HARDWARE_TIMER_INTERFACES                                      \
-    dataport Buf(4096) systimer_mem;                                   \
-    dataport Buf(4096) sp804_mem;                                      \
-    consumes TimerIRQ systimer_irq;                                    \
-    consumes TimerIRQ sp804_irq;
-
+#define HARDWARE_TIMER_INTERFACES                                        \
+    emits Dummy dummy_source;                                            \
+    consumes Dummy system_timer;
 #define HARDWARE_TIMER_ATTRIBUTES
 #define HARDWARE_TIMER_COMPOSITION                                       \
-        component HWTimer systimer;                                      \
-        connection seL4HardwareMMIO systimer_mem(from systimer_mem,      \
-                                                 to systimer.mem);       \
-        connection seL4HardwareInterrupt systimer_irq(from systimer.irq, \
-                                                      to systimer_irq);  \
-        component HWTimer sp804timer;                                    \
-        connection seL4HardwareMMIO sp804_mem(from sp804_mem,            \
-                                              to sp804timer.mem);        \
-        connection seL4HardwareInterrupt sp804_irq(from sp804timer.irq,  \
-                                                   to sp804_irq);
+        connection seL4DTBHardware system_timer_conn(from dummy_source, to system_timer);
 #define HARDWARE_TIMER_CONFIG                                            \
-    systimer.mem_paddr = 0xfe003000;                                     \
-    systimer.mem_size = 0x1000;                                          \
-    systimer.irq_irq_number = 97;                                        \
-    sp804timer.mem_paddr = 0xfe00b000;                                   \
-    sp804timer.mem_size = 0x1000;                                        \
-    sp804timer.irq_irq_number = 64;
+        system_timer.dtb = dtb({"path" : "/soc/timer@7e003000"});        \
+        system_timer.generate_interrupts = 1;
 #define HARDWARE_TIMER_PLAT_INTERFACES

--- a/components/TimeServer/include/plat/bcm2711/plat/timers.h
+++ b/components/TimeServer/include/plat/bcm2711/plat/timers.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+#define HARDWARE_TIMER_COMPONENT                                       \
+    component HWTimer {                                                \
+        hardware;                                                      \
+        dataport Buf(4096) mem;                                        \
+        emits TimerIRQ irq;                                            \
+    }
+
+#define HARDWARE_TIMER_INTERFACES                                      \
+    dataport Buf(4096) systimer_mem;                                   \
+    dataport Buf(4096) sp804_mem;                                      \
+    consumes TimerIRQ systimer_irq;                                    \
+    consumes TimerIRQ sp804_irq;
+
+#define HARDWARE_TIMER_ATTRIBUTES
+#define HARDWARE_TIMER_COMPOSITION                                       \
+        component HWTimer systimer;                                      \
+        connection seL4HardwareMMIO systimer_mem(from systimer_mem,      \
+                                                 to systimer.mem);       \
+        connection seL4HardwareInterrupt systimer_irq(from systimer.irq, \
+                                                      to systimer_irq);  \
+        component HWTimer sp804timer;                                    \
+        connection seL4HardwareMMIO sp804_mem(from sp804_mem,            \
+                                              to sp804timer.mem);        \
+        connection seL4HardwareInterrupt sp804_irq(from sp804timer.irq,  \
+                                                   to sp804_irq);
+#define HARDWARE_TIMER_CONFIG                                            \
+    systimer.mem_paddr = 0xfe003000;                                     \
+    systimer.mem_size = 0x1000;                                          \
+    systimer.irq_irq_number = 97;                                        \
+    sp804timer.mem_paddr = 0xfe00b000;                                   \
+    sp804timer.mem_size = 0x1000;                                        \
+    sp804timer.irq_irq_number = 64;
+#define HARDWARE_TIMER_PLAT_INTERFACES


### PR DESCRIPTION
This PR adds support for RPi4 on the TimeServer component.
The timer component is generated from the device tree.

Also the missing GPIO MMIO mapping is added to the SerialServer
component. This enables using the SerialServer component with
new serial drivers in 'util_libs'. However, this fix won't help if the serial
driver(s) are used as-is without SerialServer component, and another
workaround is needed for the missing mapping.

Test with:
https://github.com/seL4/seL4/pull/894
https://github.com/seL4/util_libs/pull/134