### PR TITLE
ethdriver: add has_rx method

### DIFF
--- a/components/Ethdriver/src/ethdriver.c
+++ b/components/Ethdriver/src/ethdriver.c
@@ -298,6 +298,22 @@ int client_rx(int *len)
     return ret;
 }
 
+int client_has_rx(void)
+{
+    if (!done_init) {
+        return -1;
+    }
+
+    client_t *client = eth_get_client();
+    assert(client);
+
+    if ((client->pending_rx_head != client->pending_rx_tail) &&
+        (0 == client->should_notify)) {
+        return 1;
+    }
+    return 0;
+}
+
 int client_tx(int len)
 {
     if (!done_init) {

--- a/interfaces/Ethdriver.idl4
+++ b/interfaces/Ethdriver.idl4
@@ -7,5 +7,6 @@
 procedure Ethdriver {
     int tx(in int len);
     int rx(out int len);
+    int has_rx(void);
     void mac(out uint8_t b1, out uint8_t b2, out uint8_t b3, out uint8_t b4, out uint8_t b5, out uint8_t b6);
 };


### PR DESCRIPTION
Add callback function for upstream components to check if the Ethdriver has available RX data.

DornerWorks has used this method in conjunction with a polling Router component.