### PR TITLE
Ethdriver: Add workaround for DMA cachability conf

### DIFF
--- a/components/Ethdriver/src/ethdriver.c
+++ b/components/Ethdriver/src/ethdriver.c
@@ -385,6 +385,9 @@ int server_init(ps_io_ops_t *io_ops)
     /* preallocate buffers */
     for (int i = 0; i < RX_BUFS; i++) {
         void *buf = ps_dma_alloc(&io_ops->dma_manager, BUF_SIZE, 4, 1, PS_MEM_NORMAL);
+        if (!buf) {
+            buf = ps_dma_alloc(&io_ops->dma_manager, BUF_SIZE, 4, 0, PS_MEM_NORMAL);
+        }
         assert(buf);
         memset(buf, 0, BUF_SIZE);
         uintptr_t phys = ps_dma_pin(&io_ops->dma_manager, buf, BUF_SIZE);
@@ -402,6 +405,9 @@ int server_init(ps_io_ops_t *io_ops)
         clients[client].dataport = client_buf(clients[client].client_id);
         for (int i = 0; i < CLIENT_TX_BUFS; i++) {
             void *buf = ps_dma_alloc(&io_ops->dma_manager, BUF_SIZE, 4, 1, PS_MEM_NORMAL);
+            if (!buf) {
+                buf = ps_dma_alloc(&io_ops->dma_manager, BUF_SIZE, 4, 0, PS_MEM_NORMAL);
+            }
             assert(buf);
             memset(buf, 0, BUF_SIZE);
             uintptr_t phys = ps_dma_pin(&io_ops->dma_manager, buf, BUF_SIZE);


### PR DESCRIPTION
Previously, the camkes runtime would ignore the cacheability attribute of the DMA memory request and just return a static DMA memory mapping that would work for the platform (cached on x86 and uncached on non-x86). Now that the runtime respects the cacheability argument the ethdriver component can just try both combinations and expect one of the allocations to work if the component has been configured with a DMA pool.

Signed-off-by: Kent McLeod <kent@kry10.com>