### PR TITLE
Update function signatures to use seL4_Word

### DIFF
--- a/components/Ethdriver/src/ethdriver.c
+++ b/components/Ethdriver/src/ethdriver.c
@@ -108,8 +108,8 @@ static int done_init = 0;
 void client_emit(unsigned int client_id);
 unsigned int client_get_sender_id(void);
 unsigned int client_num_badges(void);
-unsigned int client_enumerate_badge(unsigned int i);
-void *client_buf(unsigned int client_id);
+seL4_Word client_enumerate_badge(unsigned int i);
+void *client_buf(seL4_Word client_id);
 bool client_has_mac(unsigned int client_id);
 void client_get_mac(unsigned int client_id, uint8_t *mac);
 


### PR DESCRIPTION
When trying to build the `picoserver` example from the [CAmkES repo](XXX), I ran into the following compiler error:

```
/home/user/camkes-manifest/projects/global-components/components/Ethdriver/src/ethdriver.c:111:14: error: conflicting types for 'clie
nt_enumerate_badge'; have 'unsigned int(unsigned int)'
  111 | unsigned int client_enumerate_badge(unsigned int i);
      |              ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/user/camkes-manifest/picoserver/ethdriver/include/camkes.h:4,
                 from /home/user/camkes-manifest/projects/global-components/components/Ethdriver/src/ethdriver.c:11:
/home/user/camkes-manifest/picoserver/ethdriver/include/client_seL4Ethdriver_0.h:18:11: note: previous declaration of 'client_enumera
te_badge' with type 'seL4_Word(unsigned int)' {aka 'long unsigned int(unsigned int)'}
   18 | seL4_Word client_enumerate_badge(unsigned int i);
      |           ^~~~~~~~~~~~~~~~~~~~~~
/home/user/camkes-manifest/projects/global-components/components/Ethdriver/src/ethdriver.c:112:7: error: conflicting types for 'clien
t_buf'; have 'void *(unsigned int)'
  112 | void *client_buf(unsigned int client_id);
      |       ^~~~~~~~~~
In file included from /home/user/camkes-manifest/picoserver/ethdriver/include/camkes.h:4,
                 from /home/user/camkes-manifest/projects/global-components/components/Ethdriver/src/ethdriver.c:11:
/home/user/camkes-manifest/picoserver/ethdriver/include/client_seL4Ethdriver_0.h:15:8: note: previous declaration of 'client_buf' wit
h type 'void *(seL4_Word)' {aka 'void *(long unsigned int)'}
   15 | void * client_buf(seL4_Word client_id);
      |        ^~~~~~~~~~
```

The problem seems to be with the `Ethdriver` component using `unsigned int` in type signatures, rather than `seL4_Word`. This branch changes `Ethdriver` to use `seL4_Word`, so that it compiles.